### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://evangeline-liu.visualstudio.com/c875521d-e408-4588-865e-fd1257247d48/43cfccf3-634f-4d04-9cf7-8b6d39bdd63a/_apis/work/boardbadge/f93fd011-54b0-490f-a06d-1de0669a40aa)](https://evangeline-liu.visualstudio.com/c875521d-e408-4588-865e-fd1257247d48/_boards/board/t/43cfccf3-634f-4d04-9cf7-8b6d39bdd63a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#583](https://evangeline-liu.visualstudio.com/c875521d-e408-4588-865e-fd1257247d48/_workitems/edit/583). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.